### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,7 @@
   "bugs": {
     "url": "https://github.com/Grievoushead/grunt-concat-blocks/issues"
   },
-  "license": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/Grievoushead/grunt-concat-blocks/blob/master/MIT-LICENSE.txt"
-    }
-  ],
+  "license": "MIT",
   "main": "grunt.js",
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
